### PR TITLE
Fixes to Downloads, Web Browser and Controller tabs on Settings

### DIFF
--- a/resource/layout/subpaneloptionsbrowser.layout
+++ b/resource/layout/subpaneloptionsbrowser.layout
@@ -10,9 +10,7 @@
 
 		ClientBrowserAuthHomePage { ControlName=CheckButton fieldName="ClientBrowserAuthHomePage" }
 		
-		ClearWebCacheButton { ControlName=Button labelText="#Steam_SettingsBrowserClearWebCache" 	command=ClearWebCache }
-		ClearAllCookiesButton { ControlName=Button labelText="#Steam_SettingsBrowserClearAllCookies" 	command=ClearCookies }
-
+		ClearAllBrowserDataButton { ControlName=Button labelText="#Steam_SettingsBrowserDeleteAllData" 	command=ClearAllBrowserData }
 	}
 	
 	colors
@@ -31,8 +29,6 @@
 			padding-top=0
 			padding-bottom=0
 		}
-		
-		
 	}
 	
 	layout
@@ -42,8 +38,7 @@
 		place { start=OverlayHomePageLabel controls=OverlayHomePage dir=down margin-top=5 width=240 }
 		place { start=OverlayHomePage controls=ClientBrowserAuthHomePage dir=down region=bottom width=max margin-top=15 }
 		place { start=ClientBrowserAuthHomePage controls=Divider1 dir=down region=bottom width=max margin-top=15 }
-		place { start=Divider1 controls=ClearWebCacheButton height=20 width=240 region=bottom dir=down margin-top=15 }
-		place { start=ClearWebCacheButton controls=ClearAllCookiesButton height=20 width=240 region=bottom dir=down margin-top=15 }
+		place { start=Divider1 controls=ClearAllBrowserDataButton height=20 width=240 region=bottom dir=down margin-top=15 }
 		
 	}
 }

--- a/resource/layout/subpaneloptionscontroller.layout
+++ b/resource/layout/subpaneloptionscontroller.layout
@@ -13,6 +13,7 @@
 		GuideConfigButton { ControlName=Button labelText="#Steam_SettingsControllerGuideConfig" 	command=EditGuideConfig }				
 		Divider2 { ControlName=Divider	}
 		DisableNotificationsCheckbox { controlname=checkbutton labeltext="#Steam_SteamInputDisableNotifications"}
+		DisableDualSenseUpdatesCheckbox { controlname=checkbutton labeltext="#Steam_SteamInputDisableDualSenseUpdates"}
 	}
 	
 	colors
@@ -45,10 +46,9 @@
 		place { start=DescriptionLabel controls=GeneralSettingsButton width=240 region=top dir=down margin-top=15 }
 		place { start=GeneralSettingsButton controls=Divider1 height=20 region=top dir=down width=max }		
 		place { start=Divider1 controls=DescriptionBindingLabel region=top dir=down margin-top=15 width=max }			
-		place { start=DescriptionBindingLabel controls=BigPictureConfigButton width=240 region=top dir=down margin-top=15 }	
-		place { start=BigPictureConfigButton controls=DesktopConfigButton width=240 region=top dir=down margin-top=15 }			
-		place { start=DesktopConfigButton controls=GuideConfigButton width=240 region=top dir=down margin-top=15 }								
+		place { start=DescriptionBindingLabel controls="BigPictureConfigButton,DesktopConfigButton,GuideConfigButton" width=240 region=top dir=down spacing=8 margin-top=15 }								
 		place { start=GuideConfigButton controls=Divider2 height=20 region=top dir=down width=max}		
 		place { start=Divider2 controls=DisableNotificationsCheckbox region=top dir=down margin-top=15 }
+		place { start=DisableNotificationsCheckbox controls=DisableDualSenseUpdatesCheckbox width=max region=top dir=down }
 	}
 }

--- a/resource/layout/subpaneloptionsdownloads.layout
+++ b/resource/layout/subpaneloptionsdownloads.layout
@@ -2,32 +2,24 @@
 {
 	controls
 	{
-		RegionLabel {	controlname=label	labeltext=#Steam_RegionLabel	style=highlight 	}
-		LibrariesLabel {	controlname=label	labeltext=#Steam_LibrariesLabel	style=highlight }
+		RegionLabel { controlname=label labeltext=#Steam_RegionLabel style=highlight }
+		DownloadRegionCombo	{ controlname=combobox editable="0"	}
+		RegionInfoLabel { controlname=label labeltext=#Steam_RegionInfo wrap=1 }
+		
 		RestrictionsLabel {	controlname=label	labeltext=#Steam_DownloadRestrictionsLabel	style=highlight 	}
-		RegionInfoLabel {	controlname=label labeltext=#Steam_RegionInfo wrap=1		}
+		
 		ManageInstalledappsLabel { controlname=label labeltext=#SteamUI_ContentMgr_ManageInstalledAppsInfo }
 		FlushDownloadConfigLabel { controlname=label labeltext=#SteamUI_ContentMgr_FlushDownloadConfigInfo tooltiptext=#SteamUI_ContentMgr_FlushDownloadConfigTip }
 				
 		ThrottleCheckbox { controlname=checkbutton  labeltext=#Steam_ThrottleRatesLabel }
-		ThrottleRateCurrent { controlname=label }
-		ThrottleRateEditLabel { controlname=label labeltext=#SteamUI_ThrottleEditLabel }
+
 		ThrottleRateEdit { controlname=textentry }
 		ThrottleRateEditSuffix { controlname=label }
-		ThrottleRateApply 
-		{ 
-			controlname=button 
-			labeltext = #SteamUI_ThrottleApplyChange
-			command=ChangeThrottleValue
-		}
 
-		
-		DownloadRegionCombo
-		{
-			controlname=combobox
-			editable="0"
-		}
-		
+		PeerContentLabel { controlname=label labeltext=#Steam_PeerContentTitle style=highlight group="PeerContentEnabled"}
+		PeerContentCombo	{ controlname=combobox editable="0"	group="PeerContentEnabled"}
+		PeerContentInfoLabel { controlname=label labeltext=#Steam_PeerContentInfo wrap=1 group="PeerContentEnabled" }
+				
 		ManageInstalledApps
 		{
 			controlname=button
@@ -50,9 +42,10 @@
 		ThrottleDownloadsWhileStreamingCheckbox { controlname=checkbutton labeltext=#Steam_ThrottleDownloadsWhileStreaming tooltiptext=#Steam_ThrottleDownloadsWhileStreamingDetails }
 		DownloadRatesInBitsCheckbox { controlname=checkbutton labeltext=#Steam_DownloadRatesInBits }
 				
-		Divider1 { ControlName=Divider	}				
-		Divider2 { ControlName=Divider	}				
-		Divider3 { ControlName=Divider	}	
+		
+		Divider1 { ControlName=Divider }
+		Divider2 { ControlName=Divider }				
+		Divider3 { ControlName=Divider group="PeerContentEnabled" }	
 		
 	}
 	
@@ -81,44 +74,39 @@
 	{
 		region { name=box margin-top=10 margin-bottom=20 margin-left=20 margin-right=20 width=max height=max }
 
-		place { controls="LibrariesLabel" region=box margin-top=10 dir=down }
-		place { controls="ManageInstalledApps" region=box start=LibrariesLabel margin-top=10 width=235 height=25 dir=down }
-		place { controls="ManageInstalledappsLabel" region=box start=ManageInstalledApps margin-top=10 width=max dir=down }		
+		place { controls="RegionLabel" region=box margin-top=10 dir=down }
+		place { controls="DownloadRegionCombo" region=box start=RegionLabel margin-top=10 width=235 height=25 dir=down }
+		place { controls="RegionInfoLabel" region=box start=DownloadRegionCombo margin-top=10 width=max dir=down }		
 
-		place { controls="Divider1" region=box start=ManageInstalledappsLabel dir=down margin-top=15 width=max }
+		place { controls="Divider1" region=box start=RegionInfoLabel dir=down margin-top=15 width=max }
 
-		place { controls="RegionLabel" region=box start=Divider1 dir=down margin-top=15 }
-		place { controls="DownloadRegionCombo" region=box start=RegionLabel margin-top=10 height=25 width=235 dir=down }
-		place { controls="RegionInfoLabel" region=box start=DownloadRegionCombo margin-top=10 width=max dir=down }
-
-		place { controls="Divider2" region=box start=RegionInfoLabel dir=down width=max margin-top=15 }
-
-		place { controls="RestrictionsLabel" region=box start=Divider2 dir=down margin-top=15 }
+		place { controls="RestrictionsLabel" region=box start=Divider1 dir=down margin-top=15 }
 
 		place { controls="AutoUpdateTimeRestrictCheckbox" region=box start=RestrictionsLabel dir=down margin-top=4 }
-		place { controls="AutoUpdateTimeRestrictStart" region=box start=AutoUpdateTimeRestrictCheckbox dir=down margin-top=8 width=78 margin-left=10 }
+		place { controls="AutoUpdateTimeRestrictStart" region=box start=AutoUpdateTimeRestrictCheckbox dir=down margin-top=4 width=83 }
 		place { controls="AutoUpdateTimeRestrictEndLabel" region=box start=AutoUpdateTimeRestrictStart dir=right margin-left=10 }
-		place { controls="AutoUpdateTimeRestrictEnd" region=box start=AutoUpdateTimeRestrictEndLabel dir=right margin-left=10 width=78 }
+		place { controls="AutoUpdateTimeRestrictEnd" region=box start=AutoUpdateTimeRestrictEndLabel dir=right margin-left=10 width=83 }
 
-		place { controls="ThrottleCheckbox" region=box start=RestrictionsLabel dir=down margin-top=4 margin-left=270 }
-		place { controls="ThrottleRateCurrent" region=box start=ThrottleCheckbox dir=right width=235 height=25 margin-top=1 }
-		place { controls="ThrottleRateEditLabel" region=box start=ThrottleCheckbox dir=down width=175 height=25 margin-top=5}
-		place { controls="ThrottleRateEdit" region=box start=ThrottleRateEditLabel dir=down width=125 height=25 }
-		place { controls="ThrottleRateEditSuffix" region=box start=ThrottleRateEdit dir=right margin-left=4 margin-top=5 }
-		place { controls="ThrottleRateApply" region=box start=ThrottleRateEditSuffix dir=right width=70 height=25 margin-left=10 margin-top=-5}
-
-
-		place { controls="AllowDownloadsDuringGameplayCheckbox" region=box start=AutoUpdateTimeRestrictStart dir=down margin-top=10 margin-left=-10 }
+		place { controls="AllowDownloadsDuringGameplayCheckbox" region=box start=AutoUpdateTimeRestrictStart dir=down margin-top=4 }
 		place { controls="ThrottleDownloadsWhileStreamingCheckbox" region=box start=AllowDownloadsDuringGameplayCheckbox dir=down }
 		place { controls="DownloadRatesInBitsCheckbox" region=box start=ThrottleDownloadsWhileStreamingCheckbox dir=down }
 
-		place { controls="Divider3" region=box start=DownloadRatesInBitsCheckbox dir=down width=max margin-top=10 }
+		place { controls="ThrottleCheckbox" region=box start=DownloadRatesInBitsCheckbox dir=down}
+		place { controls="ThrottleRateEdit" region=box start=ThrottleCheckbox dir=down width=125 height=25 margin-top=4 }
+		place { controls="ThrottleRateEditSuffix" region=box start=ThrottleRateEdit dir=right margin-left=4 margin-top=5 }
 
-		place { controls="FlushDownloadConfig" region=box start=Divider3 margin-top=15 width=235 height=25 dir=down }
-		place { controls="FlushDownloadConfigLabel" region=box start=FlushDownloadConfig margin-top=10 width=max dir=down }
-		
-		
+		place { controls="Divider2" region=box start=ThrottleRateEdit dir=down width=max margin-top=15 }
 
+		place { controls="ManageInstalledApps" region=box start=Divider2 margin-top=15 width=235 height=25 dir=down }
+		place { controls="ManageInstalledappsLabel" region=box start=ManageInstalledApps margin-top=10 width=max dir=down }		
 
+		place { controls="FlushDownloadConfig" region=box start=ManageInstalledappsLabel margin-top=15 width=235 height=25 dir=down }
+		place { controls="FlushDownloadConfigLabel" region=box start=FlushDownloadConfig margin-top=8 width=max dir=down }
+
+		place { controls="Divider3" region=box start=FlushDownloadConfigLabel dir=down width=max margin-top=10 }
+
+		place { controls="PeerContentLabel" region=box start=Divider3 dir=down margin-top=10 width=max }
+		place { controls="PeerContentCombo" region=box start=PeerContentLabel dir=down margin-top=10 width=235 }
+		place { controls="PeerContentInfoLabel" region=box start=PeerContentCombo dir=down margin-top=8 width=max }
 	}
 }


### PR DESCRIPTION
Fixes for missing items and design suggestions that might fit better if we're trying to imitate UWP design.

Downloads
- Removed AutoUpdateTimeRestrict left padding to follow UWP design (Windows boxes usually go directly below the label without any padding)
- Adjusted ThrottleRate textbox position and moved below Checkbox to follow UWP design

Web Browser
- Removed old buttons and replaced for new ClearAllBrowserDataButton

Controller
- Adjusted Big Picture, Desktop and Button Chord buttons spacing to be the same as the buttons in the Account tab
- Adjusted and fixed DualSenseUpdates checkbox position